### PR TITLE
Agregar header para saber que version de lib y de java esta conectandose a conekta api

### DIFF
--- a/src/main/java/conekta/io/client/ConektaRequestor.java
+++ b/src/main/java/conekta/io/client/ConektaRequestor.java
@@ -62,7 +62,7 @@ public abstract class ConektaRequestor {
                 .uri(URI.create(environment + path))
                 .setHeader(Constants.CONTENT_TYPE, Constants.APPLICATION_JSON_CHARSET_UTF_8)
                 .setHeader(Constants.ACCEPT, Constants.APPLICATION_VND_CONEKTA_V_2_0_0_JSON)
-                .setHeader(Constants.USER_AGENT, Constants.API_NAME_VALUE + Constants.SLASH + Constants.LIB_VERSION)
+                .setHeader(Constants.USER_AGENT, Constants.LIB_NAME + Constants.SLASH + Constants.LIB_VERSION)
                 .build();
         return send(request);
     }

--- a/src/main/java/conekta/io/client/ConektaRequestor.java
+++ b/src/main/java/conekta/io/client/ConektaRequestor.java
@@ -62,6 +62,7 @@ public abstract class ConektaRequestor {
                 .uri(URI.create(environment + path))
                 .setHeader(Constants.CONTENT_TYPE, Constants.APPLICATION_JSON_CHARSET_UTF_8)
                 .setHeader(Constants.ACCEPT, Constants.APPLICATION_VND_CONEKTA_V_2_0_0_JSON)
+                .setHeader(Constants.USER_AGENT, Constants.API_NAME_VALUE + Constants.SLASH + Constants.LIB_VERSION)
                 .build();
         return send(request);
     }

--- a/src/main/java/conekta/io/config/Constants.java
+++ b/src/main/java/conekta/io/config/Constants.java
@@ -16,6 +16,9 @@ public class Constants {
     public static final int HTTP_CLIENT_TIMEOUT = 15;
     public static final String PAYMENT_SOURCES = "/payment_sources";
     public static final String WEBHOOKS_PATH = "/webhooks";
+    public static final String API_NAME_VALUE = "ct-conekta-java";
+    public static final String USER_AGENT = "user_agent";
+
 
     private Constants() {
         throw new IllegalStateException("Utility class");
@@ -40,9 +43,9 @@ public class Constants {
     }
 
     /**
-     * Version of the Conekta API to use.
+     * Version of the library to use.
      */
-    public static final String API_VERSION = "2.1.1";
+    public static final String LIB_VERSION = "0.0.7";
 
     /**
      * Locale to use when building requests to the Conekta API.

--- a/src/main/java/conekta/io/config/Constants.java
+++ b/src/main/java/conekta/io/config/Constants.java
@@ -16,7 +16,7 @@ public class Constants {
     public static final int HTTP_CLIENT_TIMEOUT = 15;
     public static final String PAYMENT_SOURCES = "/payment_sources";
     public static final String WEBHOOKS_PATH = "/webhooks";
-    public static final String API_NAME_VALUE = "ct-conekta-java";
+    public static final String LIB_NAME = "ct-conekta-java";
     public static final String USER_AGENT = "User-Agent";
 
 

--- a/src/main/java/conekta/io/config/Constants.java
+++ b/src/main/java/conekta/io/config/Constants.java
@@ -17,7 +17,7 @@ public class Constants {
     public static final String PAYMENT_SOURCES = "/payment_sources";
     public static final String WEBHOOKS_PATH = "/webhooks";
     public static final String API_NAME_VALUE = "ct-conekta-java";
-    public static final String USER_AGENT = "user_agent";
+    public static final String USER_AGENT = "User-Agent";
 
 
     private Constants() {


### PR DESCRIPTION
Se realizó un pequeño agregado a las request por parte de la lib java para que incorporen el nombre y la versión que se está consumiendo.