### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,6 +15,8 @@ jobs:
   build:
     name: Build Conekta API
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         java: [ '11' ]


### PR DESCRIPTION
Potential fix for [https://github.com/conekta/ct-conekta-java/security/code-scanning/2](https://github.com/conekta/ct-conekta-java/security/code-scanning/2)

In general, the fix is to explicitly specify the `permissions` for the `GITHUB_TOKEN` in the workflow, limiting them to the minimum required. Since this workflow only checks out code and builds/tests it, it only needs read access to repository contents (and possibly packages if Maven were pushing to GitHub Packages, which it is not here). Therefore, we can safely add `permissions: contents: read` either at the workflow root (to apply to all jobs) or specifically under the `build` job. The CodeQL message suggests at least `contents: read` as a minimal starting point.

The single best fix, with minimal behavior change, is to add a job-level `permissions` block under `jobs.build` so that only this job is constrained, leaving other potential jobs unaffected. Concretely, in `.github/workflows/maven.yml`, under the `build` job and at the same indentation level as `runs-on`, insert:
```yaml
    permissions:
      contents: read
```
No imports or additional definitions are required; this is pure workflow configuration. This change documents and enforces least-privilege access for the GITHUB_TOKEN used in this CI workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
