### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/conekta/ct-conekta-java/security/code-scanning/4](https://github.com/conekta/ct-conekta-java/security/code-scanning/4)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.  
Best single fix here (without changing workflow behavior) is to set workflow-level permissions to:

- `contents: read`

This supports checkout while preventing unnecessary write scopes.  
Change file: `.github/workflows/maven-deploy.yml`, near the top-level keys (`name`, `on`, `jobs`), by inserting `permissions` between `on` and `jobs` (or any top-level location).

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
